### PR TITLE
add additional check on tournament id

### DIFF
--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -71,7 +71,7 @@ export const getBonusPartsQuery = db.prepare(`
     JOIN    packet ON bonus.packet_id = packet.id
     JOIN    question_set ON packet.question_set_id = question_set.id
     JOIN    tournament ON question_set.id = tournament.question_set_id
-    JOIN    round ON round.packet_id = packet.id
+    JOIN    round ON round.packet_id = packet.id and round.tournament_id = tournament.id
     JOIN    bonus_part on bonus.id = bonus_part.bonus_id
     WHERE   tournament.id = ?
         AND round.number = ?


### PR DESCRIPTION
For some reason, bonus parts were being duplicated without this additional check in the SQL query. Not sure why it's needed, but it fixed all the issues for me.