### PR TITLE
Fix broken link in team table + add team to player table

### DIFF
--- a/src/components/common/PlayerTable.tsx
+++ b/src/components/common/PlayerTable.tsx
@@ -16,6 +16,12 @@ export function PlayerTable({ players }: PlayerTableProps) {
             html: true
         },
         {
+            key: "team_name",
+            label: "Team",
+            linkTemplate: "/tournament/{{tournament_slug}}/team/{{team_slug}}",
+            html: true
+        },
+        {
             key: "powers",
             label: "Powers",
             defaultDescending: true

--- a/src/components/common/TeamTable.tsx
+++ b/src/components/common/TeamTable.tsx
@@ -12,7 +12,7 @@ export function TeamTable({ teams }: TeamTableProps) {
         {
             key: "name",
             label: "Team",
-            linkTemplate: "/tournament/{{tournament_slug}}/team/{{name}}",
+            linkTemplate: "/tournament/{{tournament_slug}}/team/{{slug}}",
             html: true
         },
         {

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -574,6 +574,7 @@ WITH raw_buzzes AS (
         FROM	raw_buzzes b1
     )
 SELECT  team.name,
+        team.slug,
         tournament.slug as tournament_slug,
         sum(iif(buzz.value > 10, 1, 0)) as powers,
         sum(iif(buzz.value = 10, 1, 0)) as gets,

--- a/src/utils/queries.ts
+++ b/src/utils/queries.ts
@@ -531,6 +531,8 @@ WITH raw_buzzes AS (
     SELECT	buzz.player_id,
             player.name,
             player.slug,
+            team.name as team_name,
+            team.slug as team_slug,
             tournament.slug as tournament_slug,
             sum(iif(buzz.value > 10, 1, 0)) as powers,
             sum(iif(buzz.value = 10, 1, 0)) as gets,
@@ -542,14 +544,15 @@ WITH raw_buzzes AS (
             sum(iif(top_three.tossup_id is not null, 1, 0)) as top_three_buzzes,
             sum(iif(neg.tossup_id is not null, 1, 0)) bouncebacks
     FROM	tournament
-    JOIN	round ON tournament_id = tournament.id
+    JOIN	round ON team.tournament_id = tournament.id
     JOIN	game ON round_id = round.id
     JOIN	buzz ON buzz.game_id = game.id
     JOIN	player ON buzz.player_id = player.id
+    JOIN	team ON player.team_id = team.id
     LEFT JOIN	buzz_ranks first ON buzz.tossup_id = first.tossup_id AND buzz.buzz_position = first.buzz_position AND first.row_num = 1 AND buzz.value > 0
     LEFT JOIN   buzz_ranks top_three ON buzz.tossup_id = top_three.tossup_id AND buzz.buzz_position = top_three.buzz_position AND top_three.row_num <= 3 AND buzz.value > 0
     LEFT JOIN	buzz neg ON buzz.game_id = neg.game_id AND buzz.tossup_id = neg.tossup_id AND buzz.value > 0 AND neg.value < 0
-    WHERE	tournament_id = ?
+    WHERE	team.tournament_id = ?
         AND	exclude_from_individual = 0
     group by buzz.player_id, player.name, player.slug
 `)


### PR DESCRIPTION
The team table had broken links to team pages due to using team name instead of team slug in the link -- this PR fixes that and also adds team name to the player table for comprehensibility.